### PR TITLE
Update to support proxy configuration at CPP level

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ clean:
 	rm -f vendors/*.target.mk
 
 ios: _build_ios
-	xcodebuild -project ios/$(NAME).xcodeproj -configuration Release -target $(LIB_IOS) | ${xb-prettifier}
+	xcodebuild -project ios/$(NAME).xcodeproj -configuration Release -target $(LIB_IOS)
 
 _build_ios: _djinni
 	PYTHONPATH=vendors/gyp/pylib vendors/gyp/gyp -DOS=ios --depth=. -f xcode --generator-output ./ios -Icommon.gypi $(NAME).gyp
@@ -36,13 +36,13 @@ _build_android: _djinni
 	ANDROID_BUILD_TOP=dirname PYTHONPATH=vendors/gyp/pylib $(which ndk-build) vendors/gyp/gyp --depth=. -f android -DOS=android --root-target $(LIB_ANDROID) -Icommon.gypi $(NAME).gyp
 
 lib: _build_lib
-	xcodebuild -project cpp/$(NAME).xcodeproj -configuration Release -target $(LIB_IOS) | ${xb-prettifier}
+	xcodebuild -project cpp/$(NAME).xcodeproj -configuration Release -target $(LIB_IOS)
 
 _build_lib: _djinni
 	PYTHONPATH=vendors/gyp/pylib vendors/gyp/gyp -DOS=lib --depth=. -f xcode --generator-output ./cpp -Icommon.gypi $(NAME).gyp
 
 test: _djinni
-	xcodebuild -project cpp/$(NAME).xcodeproj -configuration Debug TEST_MODE=1 -target test  | ${xb-prettifier} && ./build/Debug/test
+	xcodebuild -project cpp/$(NAME).xcodeproj -configuration Debug TEST_MODE=1 -target test
 
 _djinni:
 	./utils/run_djinni

--- a/android/Cookpit/app/src/main/kotlin/com/github/kittinunf/cookpit/Application.kt
+++ b/android/Cookpit/app/src/main/kotlin/com/github/kittinunf/cookpit/Application.kt
@@ -15,6 +15,9 @@ class Application : android.app.Application() {
         val db = getDatabasePath("CookpitDB")
         db.mkdirs()
         Api.setPath(db.absolutePath)
+
+        //set proxy if needed
+//        Api.setProxy("192.168.11.7:8080")
     }
 
 }

--- a/common.gypi
+++ b/common.gypi
@@ -45,7 +45,8 @@
     'configurations': {
       'Debug': {
         'defines': [
-          'DEBUG=1'
+          'DEBUG=1',
+          'NDEBUG=0',
         ],
         'cflags': [
           '-DDEBUG',
@@ -61,6 +62,7 @@
       'Release': {
         'defines': [
           'NDEBUG=1',
+          'DEBUG=0',
         ],
         'cflags': [
           '-DNDEBUG',

--- a/cpp/src/api.cpp
+++ b/cpp/src/api.cpp
@@ -6,10 +6,15 @@ namespace cookpit
 {
 void api::set_path(const string& path) { instance_.path(path); }
 
+void api::set_proxy(const string& proxy) { instance_.proxy(proxy); }
+
 api_impl& api_impl::instance() { return instance_; }
 
 string api_impl::path() const { return path_; }
 void api_impl::path(const string& path) { path_ = path; }
+
+optional<string> api_impl::proxy() const { return proxy_; }
+void api_impl::proxy(const string& proxy) { proxy_ = proxy; }
 
 lmdb::env api_impl::db(const string& name) {
   auto env = lmdb::env::create();

--- a/cpp/src/api.hpp
+++ b/cpp/src/api.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
-#include "gen/api.hpp"
-
+#include <experimental/optional>
 #include <lmdb++.h>
 
+#include "gen/api.hpp"
+
 using namespace std;
+using namespace std::experimental;
 
 namespace cookpit
 {
@@ -15,9 +17,13 @@ class api_impl : public api {
   string path() const;
   void path(const string& path);
 
+  optional<string> proxy() const;
+  void proxy(const string& proxy);
+
   lmdb::env db(const string& name);
 
  private:
   string path_;
+  optional<string> proxy_ = {};
 };
 }

--- a/cpp/src/explore_controller.cpp
+++ b/cpp/src/explore_controller.cpp
@@ -42,7 +42,7 @@ void explore_controller_impl::request(int8_t page) {
   observer_->on_update(explore_view_data{false, "cache", items_});
 
   auto url = construct_url(BASE_URL, page);
-  curl_get(curl_.get(), url,
+  curl_get(curl_.get(), url, api_impl::instance().proxy(),
            [weak_self](const string& url, int /*code*/, const string& response) {
              if (auto self = weak_self.lock()) {
                self->on_success(url, response);

--- a/cpp/src/map_controller.cpp
+++ b/cpp/src/map_controller.cpp
@@ -3,6 +3,7 @@
 #include <json11.hpp>
 #include <unordered_map>
 
+#include "api.hpp"
 #include "constants.hpp"
 #include "coordinate.hpp"
 #include "gen/map_controller_observer.hpp"
@@ -35,7 +36,7 @@ void map_controller_impl::request() {
   auto query_string = convert_to_query_param_string(params);
   auto url = BASE_URL + "?" + query_string;
 
-  curl_get(curl_.get(), url,
+  curl_get(curl_.get(), url, api_impl::instance().proxy(),
            [weak_self](const string& /*url*/, int /*code*/, const string& response) {
              if (auto self = weak_self.lock()) {
                self->on_success(response);

--- a/cpp/src/photo_comment_controller.cpp
+++ b/cpp/src/photo_comment_controller.cpp
@@ -3,6 +3,7 @@
 #include <json11.hpp>
 #include <unordered_map>
 
+#include "api.hpp"
 #include "constants.hpp"
 #include "gen/photo_comment_controller_observer.hpp"
 #include "gen/photo_comment_view_data.hpp"
@@ -37,7 +38,7 @@ void photo_comment_controller_impl::request_comments() {
   auto query_string = convert_to_query_param_string(params);
   auto url = BASE_URL + "?" + query_string;
 
-  curl_get(curl_.get(), url,
+  curl_get(curl_.get(), url, api_impl::instance().proxy(),
            [weak_self](const string& /*url*/, int /*code*/, const string& response) {
              if (auto self = weak_self.lock()) {
                self->on_success(response);

--- a/cpp/src/photo_detail_controller.cpp
+++ b/cpp/src/photo_detail_controller.cpp
@@ -3,6 +3,7 @@
 #include <json11.hpp>
 #include <unordered_map>
 
+#include "api.hpp"
 #include "constants.hpp"
 #include "gen/photo_detail_controller_observer.hpp"
 #include "gen/photo_detail_view_data.hpp"
@@ -37,7 +38,7 @@ void photo_detail_controller_impl::request_detail() {
   auto query_string = convert_to_query_param_string(params);
   auto url = BASE_URL + "?" + query_string;
 
-  curl_get(curl_.get(), url,
+  curl_get(curl_.get(), url, api_impl::instance().proxy(),
            [weak_self](const string& /*url*/, int /*code*/, const string& response) {
              if (auto self = weak_self.lock()) {
                self->on_success(response);

--- a/cpp/src/search_controller.cpp
+++ b/cpp/src/search_controller.cpp
@@ -3,6 +3,7 @@
 #include <json11.hpp>
 #include <unordered_map>
 
+#include "api.hpp"
 #include "constants.hpp"
 #include "gen/search_controller_observer.hpp"
 #include "gen/search_view_data.hpp"
@@ -44,7 +45,7 @@ void search_controller_impl::search(const string& key, int8_t page) {
   auto query_string = convert_to_query_param_string(params);
   auto url = BASE_URL + "?" + query_string;
 
-  curl_get(curl_.get(), url,
+  curl_get(curl_.get(), url, api_impl::instance().proxy(),
            [weak_self](const string& /*url*/, int /*code*/, const string& response) {
              if (auto self = weak_self.lock()) {
                self->on_success(response);

--- a/cpp/src/utility.cpp
+++ b/cpp/src/utility.cpp
@@ -59,16 +59,16 @@ void curl_get(CURL* curl_handler, const string& url, const optional<string>& pro
   if (auto _proxy = proxy) {
     curl_easy_setopt(curl_handler, CURLOPT_PROXY, (*_proxy).c_str());
   }
-  cout << "-->> url: " << url << endl;
+  cout << "-->> url: " << url << '\n';
   auto res = curl_easy_perform(curl_handler);
   curl_easy_getinfo(curl_handler, CURLINFO_RESPONSE_CODE, &code);
 
   auto response = oss.str();
   if (res == CURLE_OK && (code >= 200 && code < 300)) {
-    cout << "<<-- success: " << response << endl;
+    cout << "<<-- success: " << response << '\n';
     success_callback(url, code, response);
   } else {
-    cout << "<<-- failure: " << response << endl;
+    cout << "<<-- failure: " << response << '\n';
     failure_callback(url, code, response);
   }
 }

--- a/cpp/src/utility.cpp
+++ b/cpp/src/utility.cpp
@@ -59,16 +59,18 @@ void curl_get(CURL* curl_handler, const string& url, const optional<string>& pro
   if (auto _proxy = proxy) {
     curl_easy_setopt(curl_handler, CURLOPT_PROXY, (*_proxy).c_str());
   }
-  cout << "-->> url: " << url << '\n';
+
+  if (!NDEBUG) cout << "-->> url: " << url << '\n';
+
   auto res = curl_easy_perform(curl_handler);
   curl_easy_getinfo(curl_handler, CURLINFO_RESPONSE_CODE, &code);
 
   auto response = oss.str();
   if (res == CURLE_OK && (code >= 200 && code < 300)) {
-    cout << "<<-- success: " << response << '\n';
+    if (!NDEBUG) cout << "<<-- success: " << response << '\n';
     success_callback(url, code, response);
   } else {
-    cout << "<<-- failure: " << response << '\n';
+    if (!NDEBUG) cout << "<<-- failure: " << response << '\n';
     failure_callback(url, code, response);
   }
 }

--- a/cpp/src/utility.hpp
+++ b/cpp/src/utility.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
 #include <curl/curl.h>
+#include <experimental/optional>
 #include <functional>
 #include <string>
 
 using namespace std;
+using namespace std::experimental;
 
 namespace cookpit
 {
@@ -18,5 +20,9 @@ template <typename T>
 string convert_to_query_param_string(const T& queries);
 
 void curl_get(CURL* curl_handler, const string& url, function<void(const string&, int, const string&)> success_callback,
+              function<void(const string&, int, const string&)> failure_callback);
+
+void curl_get(CURL* curl_handler, const string& url, const optional<string>& proxy,
+              function<void(const string&, int, const string&)> success_callback,
               function<void(const string&, int, const string&)> failure_callback);
 }

--- a/djinni/api.djinni
+++ b/djinni/api.djinni
@@ -1,3 +1,4 @@
 api = interface +c {
 	static set_path(path: string);
+	static set_proxy(url: string);
 }

--- a/ios/Cookpit/Cookpit/AppDelegate.swift
+++ b/ios/Cookpit/Cookpit/AppDelegate.swift
@@ -20,6 +20,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     let dbPath = (path as NSString).appendingPathComponent("CookpitDB")
     try! FileManager.default.createDirectory(atPath: dbPath, withIntermediateDirectories: true, attributes: nil);
     CPApi.setPath(dbPath)
+
+    //set proxy if needed
+//    CPApi.setProxy("10.100.69.43")
     return true
   }
 


### PR DESCRIPTION
### What's in this PR?

Due to the ability to debug the API call at Cpp layer has lost, this PR re-introduce it.

The trick is to include at the CURL layer by using the following command;

``` C++
//proxy is optional<string> proxy
if (auto _proxy = proxy) {
    curl_easy_setopt(curl_handler, CURLOPT_PROXY, (*_proxy).c_str());
}
```

#### Example

<img width="846" alt="screen shot 2018-01-22 at 22 41 35" src="https://user-images.githubusercontent.com/4669517/35223976-b50a4b7c-ffc6-11e7-9611-ef6c49845287.png">

<img width="848" alt="screen shot 2018-01-22 at 22 41 51" src="https://user-images.githubusercontent.com/4669517/35223982-b79ff3aa-ffc6-11e7-8de7-68f4acaa03f6.png">
